### PR TITLE
Fix a compatibility issue for python 3.6

### DIFF
--- a/flask_modus.py
+++ b/flask_modus.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from werkzeug import url_decode
-
+from sys import version_info
 
 class Middleware(object):
     """ WSGI Method Overriding Middleware """
@@ -26,7 +26,8 @@ class Middleware(object):
 
         def set_method(method):
             if method in self.allowed_methods:
-                method = method.encode('ascii', 'replace')
+                if version_info[0] < 3:
+                    method = method.encode('ascii', 'replace')
                 environ['REQUEST_METHOD'] = method
             if method in self.bodyless_methods:
                 environ['CONTENT_LENGTH'] = '0'


### PR DESCRIPTION
In projects using python 3 the method string is received as a bite string. This change leaves it as as unicode for python 3 projects and only convert it to ascii if the project uses 2.7.
This created some confusion in my bootcamp class. I think this fixes it and leaves functionality for 2.7 users.